### PR TITLE
Configures HTTPS with ACM, ALB and Route53

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -4,7 +4,7 @@ terraform {
     organization = "thee5176"
 
     workspaces {
-      name = "Accounting_CQRS_Dev"
+      name = "AccountingInfra"
     }
   }
   required_providers {
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.13.0"
+  required_version = ">= 1.14.3"
 }

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ module "acm" {
   project_name     = var.project_name
   environment_name = var.environment_name
 
-  domain_name      = var.domain_name
+  domain_name = var.domain_name
 }
 
 module "alb" {
@@ -53,4 +53,34 @@ module "alb" {
   web_sg_id        = module.ec2.web_sg_id
 
   depends_on = [ module.acm ]
+}
+
+# Route53 A record pointing domain to ALB
+resource "aws_route53_record" "app_domain" {
+  zone_id = module.acm.route53_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = module.alb.alb_dns_name
+    zone_id                = module.alb.alb_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [module.acm, module.alb]
+}
+
+# Route53 A record for www subdomain
+resource "aws_route53_record" "www_domain" {
+  zone_id = module.acm.route53_zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.alb_dns_name
+    zone_id                = module.alb.alb_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [module.acm, module.alb]
 }

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ module "alb" {
   domain_name      = var.domain_name
   web_sg_id        = module.ec2.web_sg_id
 
-  depends_on = [ module.acm ]
+  depends_on = [module.acm]
 }
 
 # Route53 A record pointing domain to ALB

--- a/main.tf
+++ b/main.tf
@@ -31,13 +31,26 @@ module "rds" {
   web_sg_id     = module.ec2.web_sg_id
 }
 
+module "acm" {
+  source = "./resources/acm"
+
+  project_name     = var.project_name
+  environment_name = var.environment_name
+
+  domain_name      = var.domain_name
+}
+
 module "alb" {
   source = "./resources/alb"
 
   project_name     = var.project_name
   environment_name = var.environment_name
   vpc_id           = module.vpc.vpc_id
+  certificate_arn  = module.acm.certificate_arn
   alb_subnet_ids   = module.vpc.alb_subnet_ids
   ec2_instance_id  = module.ec2.ec2_instance_id
   domain_name      = var.domain_name
+  web_sg_id        = module.ec2.web_sg_id
+
+  depends_on = [ module.acm ]
 }

--- a/main.tf
+++ b/main.tf
@@ -9,16 +9,16 @@ module "vpc" {
 module "ec2" {
   source = "./resources/ec2"
 
-  project_name         = var.project_name
-  environment_name     = var.environment_name
+  project_name     = var.project_name
+  environment_name = var.environment_name
 
   ec2_instance_type    = var.ec2_instance_type
   ec2_public_key       = var.ec2_public_key
   command_service_port = var.command_service_port
   query_service_port   = var.query_service_port
 
-  vpc_id               = module.vpc.vpc_id
-  web_subnet_id        = module.vpc.web_subnet_id
+  vpc_id        = module.vpc.vpc_id
+  web_subnet_id = module.vpc.web_subnet_id
 }
 
 module "acm" {
@@ -36,46 +36,46 @@ module "alb" {
   project_name     = var.project_name
   environment_name = var.environment_name
 
-  domain_name      = var.domain_name
-  certificate_arn  = module.acm.certificate_arn
-  alb_subnet_ids   = module.vpc.alb_subnet_ids
+  domain_name     = var.domain_name
+  certificate_arn = module.acm.certificate_arn
+  alb_subnet_ids  = module.vpc.alb_subnet_ids
 
-  ec2_instance_id  = module.ec2.ec2_instance_id
+  ec2_instance_id      = module.ec2.ec2_instance_id
   command_service_port = var.command_service_port
   query_service_port   = var.query_service_port
-  
-  vpc_id           = module.vpc.vpc_id
-  web_sg_id        = module.ec2.web_sg_id
+
+  vpc_id    = module.vpc.vpc_id
+  web_sg_id = module.ec2.web_sg_id
 
   depends_on = [module.acm]
 }
 
-# Route53 A record pointing domain to ALB
-resource "aws_route53_record" "app_domain" {
-  zone_id = module.acm.route53_zone_id
-  name    = var.domain_name
-  type    = "A"
+# # Route53 A record pointing domain to ALB
+# resource "aws_route53_record" "app_domain" {
+#   zone_id = module.acm.route53_zone_id
+#   name    = var.domain_name
+#   type    = "A"
 
-  alias {
-    name                   = module.alb.alb_dns_name
-    zone_id                = module.alb.alb_zone_id
-    evaluate_target_health = true
-  }
+#   alias {
+#     name                   = module.alb.alb_dns_name
+#     zone_id                = module.alb.alb_zone_id
+#     evaluate_target_health = true
+#   }
 
-  depends_on = [module.acm, module.alb]
-}
+#   depends_on = [module.acm, module.alb]
+# }
 
-# Route53 A record for www subdomain
-resource "aws_route53_record" "www_domain" {
-  zone_id = module.acm.route53_zone_id
-  name    = "www.${var.domain_name}"
-  type    = "A"
+# # Route53 A record for www subdomain
+# resource "aws_route53_record" "www_domain" {
+#   zone_id = module.acm.route53_zone_id
+#   name    = "www.${var.domain_name}"
+#   type    = "A"
 
-  alias {
-    name                   = module.alb.alb_dns_name
-    zone_id                = module.alb.alb_zone_id
-    evaluate_target_health = true
-  }
+#   alias {
+#     name                   = module.alb.alb_dns_name
+#     zone_id                = module.alb.alb_zone_id
+#     evaluate_target_health = true
+#   }
 
-  depends_on = [module.acm, module.alb]
-}
+#   depends_on = [module.acm, module.alb]
+# }

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,6 @@ module "ec2" {
 
   vpc_id               = module.vpc.vpc_id
   web_subnet_id        = module.vpc.web_subnet_id
-  ec2_public_key       = var.ec2_public_key
 }
 
 module "acm" {

--- a/main.tf
+++ b/main.tf
@@ -11,10 +11,12 @@ module "ec2" {
 
   project_name         = var.project_name
   environment_name     = var.environment_name
+  ec2_instance_type    = var.ec2_instance_type
   command_service_port = var.command_service_port
   query_service_port   = var.query_service_port
   vpc_id               = module.vpc.vpc_id
   web_subnet_id        = module.vpc.web_subnet_id
+  ec2_public_key       = var.ec2_public_key
 }
 
 module "rds" {
@@ -53,34 +55,4 @@ module "alb" {
   web_sg_id        = module.ec2.web_sg_id
 
   depends_on = [module.acm]
-}
-
-# Route53 A record pointing domain to ALB
-resource "aws_route53_record" "app_domain" {
-  zone_id = module.acm.route53_zone_id
-  name    = var.domain_name
-  type    = "A"
-
-  alias {
-    name                   = module.alb.alb_dns_name
-    zone_id                = module.alb.alb_zone_id
-    evaluate_target_health = true
-  }
-
-  depends_on = [module.acm, module.alb]
-}
-
-# Route53 A record for www subdomain
-resource "aws_route53_record" "www_domain" {
-  zone_id = module.acm.route53_zone_id
-  name    = "www.${var.domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = module.alb.alb_dns_name
-    zone_id                = module.alb.alb_zone_id
-    evaluate_target_health = true
-  }
-
-  depends_on = [module.acm, module.alb]
 }

--- a/main.tf
+++ b/main.tf
@@ -11,26 +11,14 @@ module "ec2" {
 
   project_name         = var.project_name
   environment_name     = var.environment_name
+
   ec2_instance_type    = var.ec2_instance_type
+  ec2_public_key       = var.ec2_public_key
   command_service_port = var.command_service_port
   query_service_port   = var.query_service_port
+
   vpc_id               = module.vpc.vpc_id
   web_subnet_id        = module.vpc.web_subnet_id
-  ec2_public_key       = var.ec2_public_key
-}
-
-module "rds" {
-  source = "./resources/rds"
-
-  project_name     = var.project_name
-  environment_name = var.environment_name
-
-  db_username   = var.db_username
-  db_password   = var.db_password
-  db_schema     = var.db_schema
-  vpc_id        = module.vpc.vpc_id
-  db_subnet_ids = module.vpc.db_subnet_ids
-  web_sg_id     = module.ec2.web_sg_id
 }
 
 module "acm" {
@@ -47,11 +35,16 @@ module "alb" {
 
   project_name     = var.project_name
   environment_name = var.environment_name
-  vpc_id           = module.vpc.vpc_id
+
+  domain_name      = var.domain_name
   certificate_arn  = module.acm.certificate_arn
   alb_subnet_ids   = module.vpc.alb_subnet_ids
+
   ec2_instance_id  = module.ec2.ec2_instance_id
-  domain_name      = var.domain_name
+  command_service_port = var.command_service_port
+  query_service_port   = var.query_service_port
+  
+  vpc_id           = module.vpc.vpc_id
   web_sg_id        = module.ec2.web_sg_id
 
   depends_on = [module.acm]

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "rds_endpoint" {
   description = "RDS access endpoint (from rds module)"
   value       = module.rds.db_endpoint
 }
+
+output "alb_dns_name" {
+  description = "ALB DNS name (from alb module)"
+  value       = module.alb.alb_dns_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,23 @@ output "alb_dns_name" {
   description = "ALB DNS name (from alb module)"
   value       = module.alb.alb_dns_name
 }
+
+output "domain_name" {
+  description = "Configured domain name"
+  value       = var.domain_name
+}
+
+output "route53_name_servers" {
+  description = "Route53 name servers (update your domain registrar with these)"
+  value       = module.acm.route53_zone_name_servers
+}
+
+output "ssl_certificate_arn" {
+  description = "SSL Certificate ARN"
+  value       = module.acm.certificate_arn
+}
+
+output "application_url" {
+  description = "Application URL with HTTPS"
+  value       = "https://${var.domain_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "ec2_instance_public_ip" {
   value       = module.ec2.ec2_public_ip
 }
 
+# output "rds_endpoint" {
+#   description = "RDS access endpoint (from rds module)"
+#   value       = module.rds.db_endpoint
+# }
+
 output "alb_dns_name" {
   description = "ALB DNS name (from alb module)"
   value       = module.alb.alb_dns_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,11 +18,6 @@ output "domain_name" {
   value       = var.domain_name
 }
 
-output "route53_name_servers" {
-  description = "Route53 name servers (update your domain registrar with these)"
-  value       = module.acm.route53_zone_name_servers
-}
-
 output "ssl_certificate_arn" {
   description = "SSL Certificate ARN"
   value       = module.acm.certificate_arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "domain_name" {
   value       = var.domain_name
 }
 
+# output "route53_name_servers" {
+#   description = "Route53 name servers (update your domain registrar with these)"
+#   value       = module.acm.route53_zone_name_servers
+# }
+
 output "ssl_certificate_arn" {
   description = "SSL Certificate ARN"
   value       = module.acm.certificate_arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,6 @@ output "ec2_instance_public_ip" {
   value       = module.ec2.ec2_public_ip
 }
 
-output "rds_endpoint" {
-  description = "RDS access endpoint (from rds module)"
-  value       = module.rds.db_endpoint
-}
-
 output "alb_dns_name" {
   description = "ALB DNS name (from alb module)"
   value       = module.alb.alb_dns_name

--- a/resources/acm/main.tf
+++ b/resources/acm/main.tf
@@ -1,49 +1,42 @@
 # # SSL Certificate
-# resource "aws_acm_certificate" "ssl_cert" {
-#   domain_name       = var.domain_name
-#   validation_method = "DNS"
+resource "aws_acm_certificate" "ssl_cert" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
 
-#   tags = {
-#       Name = "${var.project_name}_ssl_cert"
-#       Environment = var.environment_name
-#   }
+  tags = {
+      Name = "${var.project_name}_ssl_cert"
+      Environment = var.environment_name
+  }
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
-# resource "aws_route53_zone" "main" {
-#   name         = var.domain_name
-# }
+resource "aws_route53_zone" "main" {
+  name         = var.domain_name
+}
 
-# locals {
-#   cert_dvos = { for dvo in aws_acm_certificate.ssl_cert.domain_validation_options : dvo.domain_name => dvo }
-# }
-
-# # Create DNS validation records returned by ACM
-# resource "aws_route53_record" "cert_validation" {
-#   for_each = local.cert_dvos
-
-#   zone_id = aws_route53_zone.main.zone_id
-#   name    = each.value.resource_record_name
-#   type    = each.value.resource_record_type
-#   ttl     = 60
-#   records = [each.value.resource_record_value]
-# }
+resource "aws_route53_record" "cert_validation" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = tolist(aws_acm_certificate.ssl_cert.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.ssl_cert.domain_validation_options)[0].resource_record_type
+  ttl     = 60
+  records = [tolist(aws_acm_certificate.ssl_cert.domain_validation_options)[0].resource_record_value]
+}
 
 # # Validate the ACM certificate using the created Route53 records
-# resource "aws_acm_certificate_validation" "ssl_cert_validation" {
-#   certificate_arn         = aws_acm_certificate.ssl_cert.arn
-#   validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+resource "aws_acm_certificate_validation" "ssl_cert_validation" {
+  certificate_arn         = aws_acm_certificate.ssl_cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 
 #   # Ensure certificate is created before validation resource is destroyed/created
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
 # # Ensure the ALB listener waits for the certificate validation to complete
-# resource "null_resource" "wait_for_cert_validation" {
-#   depends_on = [aws_acm_certificate_validation.ssl_cert_validation]
-# }
+resource "null_resource" "wait_for_cert_validation" {
+  depends_on = [aws_acm_certificate_validation.ssl_cert_validation]
+}

--- a/resources/acm/main.tf
+++ b/resources/acm/main.tf
@@ -19,3 +19,8 @@ resource "tls_self_signed_cert" "self_signed_cert" {
     "server_auth",
   ]
 }
+
+resource "aws_acm_certificate" "my_ssl_cert" {
+  private_key      = tls_private_key.ssl_key_pair.private_key_pem
+  certificate_body = tls_self_signed_cert.self_signed_cert.cert_pem
+}

--- a/resources/acm/main.tf
+++ b/resources/acm/main.tf
@@ -19,8 +19,3 @@ resource "tls_self_signed_cert" "self_signed_cert" {
     "server_auth",
   ]
 }
-
-resource "aws_acm_certificate" "my_ssl_cert" {
-  private_key      = tls_private_key.ssl_key_pair.private_key_pem
-  certificate_body = tls_self_signed_cert.self_signed_cert.cert_pem
-}

--- a/resources/acm/outputs.tf
+++ b/resources/acm/outputs.tf
@@ -1,0 +1,4 @@
+output "certificate_arn" {
+    description = "ARN of the created ACM certificate"
+    value       = aws_acm_certificate.ssl_cert.arn
+}

--- a/resources/acm/outputs.tf
+++ b/resources/acm/outputs.tf
@@ -1,4 +1,19 @@
 output "certificate_arn" {
-    description = "ARN of the created ACM certificate"
-    value       = aws_acm_certificate.ssl_cert.arn
+  description = "ARN of the private SSL certificate imported into ACM"
+  value       = data.aws_acm_certificate.my_ssl_cert.arn
+}
+
+output "route53_zone_id" {
+  description = "Route53 hosted zone ID"
+  value       = aws_route53_zone.main.zone_id
+}
+
+output "route53_zone_name_servers" {
+  description = "Route53 hosted zone name servers"
+  value       = aws_route53_zone.main.name_servers
+}
+
+output "domain_name" {
+  description = "Domain name"
+  value       = var.domain_name
 }

--- a/resources/acm/outputs.tf
+++ b/resources/acm/outputs.tf
@@ -3,6 +3,16 @@ output "certificate_arn" {
   value       = aws_acm_certificate.my_ssl_cert.arn
 }
 
+# output "route53_zone_id" {
+#   description = "Route53 hosted zone ID"
+#   value       = aws_route53_zone.main.zone_id
+# }
+
+# output "route53_zone_name_servers" {
+#   description = "Route53 hosted zone name servers"
+#   value       = aws_route53_zone.main.name_servers
+# }
+
 output "domain_name" {
   description = "Domain name"
   value       = var.domain_name

--- a/resources/acm/outputs.tf
+++ b/resources/acm/outputs.tf
@@ -3,6 +3,11 @@ output "certificate_arn" {
   value       = aws_acm_certificate.my_ssl_cert.arn
 }
 
+output "domain_name" {
+  description = "Domain name"
+  value       = var.domain_name
+}
+
 # output "route53_zone_id" {
 #   description = "Route53 hosted zone ID"
 #   value       = aws_route53_zone.main.zone_id
@@ -12,8 +17,3 @@ output "certificate_arn" {
 #   description = "Route53 hosted zone name servers"
 #   value       = aws_route53_zone.main.name_servers
 # }
-
-output "domain_name" {
-  description = "Domain name"
-  value       = var.domain_name
-}

--- a/resources/acm/outputs.tf
+++ b/resources/acm/outputs.tf
@@ -1,16 +1,6 @@
 output "certificate_arn" {
   description = "ARN of the private SSL certificate imported into ACM"
-  value       = data.aws_acm_certificate.my_ssl_cert.arn
-}
-
-output "route53_zone_id" {
-  description = "Route53 hosted zone ID"
-  value       = aws_route53_zone.main.zone_id
-}
-
-output "route53_zone_name_servers" {
-  description = "Route53 hosted zone name servers"
-  value       = aws_route53_zone.main.name_servers
+  value       = aws_acm_certificate.my_ssl_cert.arn
 }
 
 output "domain_name" {

--- a/resources/acm/variables.tf
+++ b/resources/acm/variables.tf
@@ -1,0 +1,14 @@
+variable "project_name" {
+    description = "catagorize the project provision"
+    type        = string
+}
+
+variable "environment_name" {
+    description = "catagorize environment purpose e.g.develop, production"
+    type        = string
+}
+
+variable "domain_name" {
+    description = "Domain name for Route53"
+    type        = string
+}

--- a/resources/alb/main.tf
+++ b/resources/alb/main.tf
@@ -4,27 +4,29 @@ resource "aws_security_group" "alb_sg" {
     vpc_id      = var.vpc_id
     
     ingress {
-        description = "HTTP from anywhere"
-        from_port   = 80
-        to_port     = 80
-        protocol    = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
+        description      = "HTTP from anywhere"
+        from_port        = 80
+        to_port          = 80
+        protocol         = "tcp"
+        cidr_blocks      = ["0.0.0.0/0"]
+        ipv6_cidr_blocks = ["::/0"]
     }
     
     ingress {
-        description = "HTTPS from anywhere"
-        from_port   = 443
-        to_port     = 443
-        protocol    = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
+        description      = "HTTPS from anywhere"
+        from_port        = 443
+        to_port          = 443
+        protocol         = "tcp"
+        cidr_blocks      = ["0.0.0.0/0"]
+        ipv6_cidr_blocks = ["::/0"]
     }
 
     egress {
-        description = "All outbound traffic"
-        from_port   = 0
-        to_port     = 0
-        protocol    = "-1"
-        cidr_blocks = ["0.0.0.0/0"]
+        description      = "All outbound traffic"
+        from_port        = 0
+        to_port          = 0
+        protocol         = "-1"
+        cidr_blocks      = ["0.0.0.0/0"]
     }
 
     tags = {
@@ -35,13 +37,13 @@ resource "aws_security_group" "alb_sg" {
 
 # ALB
 resource "aws_lb" "backend_alb"{
-    # name = "${var.project_name}-backend-alb"
+    name = var.project_name
     internal = false
     load_balancer_type = "application"
     security_groups = [aws_security_group.alb_sg.id]
     subnets = var.alb_subnet_ids # Internet-facing subnets
-
-    enable_deletion_protection = true
+    enable_deletion_protection = false
+    ip_address_type = "dualstack"
     tags = {
         Name = "${var.project_name}_backend_alb"
         Environment = var.environment_name
@@ -190,20 +192,20 @@ resource "aws_lb_listener_rule" "query_rule" {
 }
 
 resource "aws_security_group_rule" "allow_alb_to_command_service" {
-  description              = "Allow ALB to reach EC2 on HTTP port 8181"
+  description              = "Allow ALB to reach EC2 on HTTP port ${var.command_service_port}"
   type                     = "ingress"
-  to_port                  = 8181
-  from_port                = 8181
+  to_port                  = var.command_service_port
+  from_port                = var.command_service_port
   protocol                 = "tcp"
   security_group_id        = var.web_sg_id
   source_security_group_id = aws_security_group.alb_sg.id
 }
 
 resource "aws_security_group_rule" "allow_alb_to_query_service" {
-  description              = "Allow ALB to reach EC2 on HTTP port 8182"
+  description              = "Allow ALB to reach EC2 on HTTP port ${var.query_service_port}"
   type                     = "ingress"
-  to_port                  = 8182
-  from_port                = 8182
+  to_port                  = var.query_service_port
+  from_port                = var.query_service_port
   protocol                 = "tcp"
   security_group_id        = var.web_sg_id
   source_security_group_id = aws_security_group.alb_sg.id

--- a/resources/alb/outputs.tf
+++ b/resources/alb/outputs.tf
@@ -2,3 +2,13 @@ output "alb_dns_name" {
   description = "The DNS name of the ALB"
   value       = aws_lb.backend_alb.dns_name
 }
+
+output "alb_zone_id" {
+  description = "The zone ID of the ALB"
+  value       = aws_lb.backend_alb.zone_id
+}
+
+output "alb_arn" {
+  description = "The ARN of the ALB"
+  value       = aws_lb.backend_alb.arn
+}

--- a/resources/alb/variables.tf
+++ b/resources/alb/variables.tf
@@ -27,3 +27,19 @@ variable "domain_name" {
     description = "Domain name for the application load balancer"
     type        = string
 }
+
+variable "certificate_arn" {
+  description = "ARN of ACM certificate to use for HTTPS; empty = create HTTP listener instead"
+  type        = string
+}
+
+variable "ssl_policy" {
+  description = "SSL policy for HTTPS listener"
+  type        = string
+  default     = "ELBSecurityPolicy-2016-08"
+}
+
+variable "web_sg_id" {
+  description = "Security group id of web (EC2) resources allowed to access by ALB"
+  type        = string
+}

--- a/resources/alb/variables.tf
+++ b/resources/alb/variables.tf
@@ -23,6 +23,16 @@ variable "ec2_instance_id" {
     type        = string
 }
 
+variable "command_service_port" {
+  description = "Port for the Command Service"
+  type        = number
+}
+variable "query_service_port" {
+  description = "Port for the Query Service"
+  type        = number
+}
+
+
 variable "domain_name" {
     description = "Domain name for the application load balancer"
     type        = string

--- a/resources/ec2/main.tf
+++ b/resources/ec2/main.tf
@@ -29,8 +29,6 @@ resource "aws_instance" "web_server" {
 
     # Clone the repository and checkout the docker directory
     git clone --recurse-submodules -j3 https://github.com/Thee5176/Accounting_CQRS_Project.git
-    cd Accounting_CQRS_Project
-    git sparse-checkout set docker react_mui_cqrs --no-cone
   EOF
 
   tags = {

--- a/resources/ec2/main.tf
+++ b/resources/ec2/main.tf
@@ -28,8 +28,8 @@ resource "aws_instance" "web_server" {
     docker-compose --version
 
     # Clone the repository and checkout the docker directory
-    git clone --recurse-submodules -j3 https://github.com/Thee5176/SpringBoot_CQRS
-    cd SpringBoot_CQRS
+    git clone --recurse-submodules -j3 https://github.com/Thee5176/Accounting_CQRS_Project.git
+    cd Accounting_CQRS_Project
     git sparse-checkout set docker react_mui_cqrs --no-cone
   EOF
 

--- a/resources/ec2/main.tf
+++ b/resources/ec2/main.tf
@@ -29,6 +29,7 @@ resource "aws_instance" "web_server" {
 
     # Clone the repository and checkout the docker directory
     git clone --recurse-submodules -j3 https://github.com/Thee5176/Accounting_CQRS_Project.git
+    
   EOF
 
   tags = {

--- a/resources/ec2/main.tf
+++ b/resources/ec2/main.tf
@@ -2,19 +2,15 @@
 # EC2
 resource "aws_instance" "web_server" {
   ami                         = "ami-000322c84e9ff1be2" #Amazon Linux 2 (ap-ne-1)
-  instance_type               = "t3.micro"
-  key_name                    = data.aws_key_pair.deployment_key.key_name
+  instance_type               = var.ec2_instance_type
+  key_name                    = aws_key_pair.deployment_key.key_name
   subnet_id                   = var.web_subnet_id
   vpc_security_group_ids      = [aws_security_group.web_sg.id]
   associate_public_ip_address = true
 
   user_data = <<EOF
     #!/bin/bash
-    
-    # Update the system
     sudo yum update -y
-
-    # Install Git
     sudo yum install -y git
 
     # Install Docker and Docker Compose
@@ -79,20 +75,13 @@ resource "aws_security_group" "web_sg" {
 }
 
 # EC2 SSH Key
-data "aws_key_pair" "deployment_key" { # Manually created on aws console
+resource "aws_key_pair" "deployment_key" {
   key_name = "github_workflow_key"
+  public_key = var.ec2_public_key
+
   tags = {
     Name    = "${var.project_name}_ec2_deployment_key"
     Environment = var.environment_name
   }
 }
 
-# # EC2 Elastic IP : Set static IP address
-# resource "aws_eip" "web_eip" {
-#   instance = aws_instance.web_server.id
-#   domain   = "vpc"
-#   tags = {
-#     Name = "${var.project_name}_ec2_eip"
-#     Environment = var.environment_name  
-#   }
-# }

--- a/resources/ec2/main.tf
+++ b/resources/ec2/main.tf
@@ -39,38 +39,33 @@ resource "aws_security_group" "web_sg" {
   description = "Allow SSH and HTTP inbound traffic"
   vpc_id      = var.vpc_id
   ingress {
-    description = "SSH from anywhere"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "SSH from anywhere"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "HTTP from anywhere"
-    from_port   = 80
-    to_port     = 80 # Frontend Port
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "HTTP from anywhere"
+    from_port        = 80
+    to_port          = 80 # Frontend Port
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
   }
-
+  
   ingress {
-    description = "Allow incoming data fetch to command service"
-    from_port   = var.command_service_port
-    to_port     = var.query_service_port
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Allow incoming data fetch to command service"
+    from_port        = var.command_service_port
+    to_port          = var.query_service_port
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
   }
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name    = "${var.project_name}_ec2_sg"
-    Environment = var.environment_name
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 

--- a/resources/ec2/outputs.tf
+++ b/resources/ec2/outputs.tf
@@ -13,3 +13,8 @@ output "ec2_instance_id"{
 	description = "Instance id of the web server"
 	value       = aws_instance.web_server.id
 }
+
+output "ec2_ipv6_address" {
+	description = "IPv6 address of the web server"
+	value       = length(aws_instance.web_server.ipv6_addresses) > 0 ? aws_instance.web_server.ipv6_addresses[0] : null
+}

--- a/resources/ec2/variable.tf
+++ b/resources/ec2/variable.tf
@@ -8,6 +8,11 @@ variable "environment_name" {
     type        = string
 }
 
+variable "ec2_instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
 variable "command_service_port" {
   description = "Port for the Command Service"
   type        = number
@@ -24,5 +29,10 @@ variable "vpc_id" {
 
 variable "web_subnet_id" {
   description = "Subnet id for EC2 instance"
+  type        = string
+}
+
+variable "ec2_public_key" {
+  description = "SSH Public Key for EC2 instance access"
   type        = string
 }

--- a/resources/rds/main.tf
+++ b/resources/rds/main.tf
@@ -59,18 +59,20 @@ resource "aws_security_group" "db_sg" {
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "Allow DB access from anywhere"
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Allow DB access from anywhere"
+    from_port        = 5432
+    to_port          = 5432
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {

--- a/resources/rds/main.tf
+++ b/resources/rds/main.tf
@@ -92,12 +92,12 @@ resource "aws_security_group" "db_sg" {
 # }
 
 # Ingress Rules
-resource "aws_security_group_rule" "ec2_to_rds_ingress" {
-  type                     = "ingress"
-  description              = "Allow DB access from anywhere web servers"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.db_sg.id
-  source_security_group_id = var.web_sg_id
-} 
+# resource "aws_security_group_rule" "ec2_to_rds_ingress" {
+#   type                     = "ingress"
+#   description              = "Allow DB access from anywhere web servers"
+#   from_port                = 5432
+#   to_port                  = 5432
+#   protocol                 = "tcp"
+#   security_group_id        = aws_security_group.db_sg.id
+#   source_security_group_id = var.web_sg_id
+# } 

--- a/resources/vpc/main.tf
+++ b/resources/vpc/main.tf
@@ -112,7 +112,6 @@ resource "aws_subnet" "db_subnet" {
 }
 
 
-#TODO : later remove and turn into private subnet -> access through alb public subnet only
 # Public Table Association : connect EC2 subnet with public route table
 resource "aws_route_table_association" "public_subnet_association" {
   subnet_id      = aws_subnet.web_subnet.id

--- a/resources/vpc/main.tf
+++ b/resources/vpc/main.tf
@@ -1,10 +1,11 @@
 ##----------------------------VPC Level--------------------------
 # VPC : define resource group
 resource "aws_vpc" "main_vpc" {
-  cidr_block           = "172.16.0.0/16"
-  instance_tenancy     = "default"
-  enable_dns_support   = true
-  enable_dns_hostnames = true
+  cidr_block                       = "172.16.0.0/16"
+  instance_tenancy                 = "default"
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  assign_generated_ipv6_cidr_block  = true
 
   tags = {
     Name    = "${var.project_name}_vpc"
@@ -42,11 +43,20 @@ resource "aws_route" "public_route" {
   route_table_id         = aws_route_table.public_route.id
 }
 
+# IPv6 Route
+resource "aws_route" "public_route_ipv6" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.main_igw.id
+  route_table_id              = aws_route_table.public_route.id
+}
+
 # EC2 Subnet (Private)
 resource "aws_subnet" "web_subnet" {
-  vpc_id            = aws_vpc.main_vpc.id
-  cidr_block        = cidrsubnet(aws_vpc.main_vpc.cidr_block, 8, 10 ) # 172.16.10.0/24
-  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id                          = aws_vpc.main_vpc.id
+  cidr_block                      = cidrsubnet(aws_vpc.main_vpc.cidr_block, 8, 10 ) # 172.16.10.0/24
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block, 8, 0)
+  availability_zone               = data.aws_availability_zones.available.names[0]
+  assign_ipv6_address_on_creation    = true
 
   tags = {
     Name    = "${var.project_name}_web_subnet"
@@ -63,9 +73,11 @@ resource "aws_subnet" "web_subnet" {
 resource "aws_subnet" "alb_subnet" {
   count = min(length(data.aws_availability_zones.available.names), 2)
 
-  vpc_id            = aws_vpc.main_vpc.id
-  cidr_block        = cidrsubnet(aws_vpc.main_vpc.cidr_block, 8, 40 + count.index) # 172.16.40.0/24, 172.16.41.0/24
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id                          = aws_vpc.main_vpc.id
+  cidr_block                      = cidrsubnet(aws_vpc.main_vpc.cidr_block, 8, 40 + count.index) # 172.16.40.0/24, 172.16.41.0/24
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block, 8, 10 + count.index)
+  availability_zone               = data.aws_availability_zones.available.names[count.index]
+  assign_ipv6_address_on_creation    = true
 
   tags = {
     Name    = "${var.project_name}_alb_subnet_${count.index + 1}"
@@ -82,9 +94,11 @@ resource "aws_subnet" "alb_subnet" {
 resource "aws_subnet" "db_subnet" {
   count = min(length(data.aws_availability_zones.available.names), 2)
 
-  vpc_id            = aws_vpc.main_vpc.id
-  cidr_block        = cidrsubnet(aws_vpc.main_vpc.cidr_block, 8, 60 + count.index) # 172.16.60.0/24, 172.16.61.0/24
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id                          = aws_vpc.main_vpc.id
+  cidr_block                      = cidrsubnet(aws_vpc.main_vpc.cidr_block, 8, 60 + count.index) # 172.16.60.0/24, 172.16.61.0/24
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block, 8, 20 + count.index)
+  availability_zone               = data.aws_availability_zones.available.names[count.index]
+  assign_ipv6_address_on_creation    = true
 
   tags = {
     Name    = "${var.project_name}_db_subnet_${count.index + 1}"

--- a/secret.tf
+++ b/secret.tf
@@ -90,20 +90,20 @@ resource "github_actions_environment_secret" "github_token" {
 resource "github_actions_environment_variable" "auth0_domain" {
   repository    = data.github_repository.repo.name
   environment   = github_repository_environment.repo_env.environment
-  variable_name = "VITE_AUTH0_DOMAIN"
+  variable_name = "AUTH0_DOMAIN"
   value         = var.auth0_domain
 }
 
 resource "github_actions_environment_variable" "auth0_client_id" {
   repository    = data.github_repository.repo.name
   environment   = github_repository_environment.repo_env.environment
-  variable_name = "VITE_AUTH0_CLIENT_ID"
+  variable_name = "AUTH0_CLIENT_ID"
   value         = var.auth0_client_id
 }
 
 resource "github_actions_environment_secret" "auth0_client_secret" {
   repository      = data.github_repository.repo.name
   environment     = github_repository_environment.repo_env.environment
-  secret_name     = "VITE_AUTH0_CLIENT_SECRET"
+  secret_name     = "AUTH0_CLIENT_SECRET"
   plaintext_value = var.auth0_client_secret
 }

--- a/secret.tf
+++ b/secret.tf
@@ -94,6 +94,13 @@ resource "github_actions_environment_variable" "auth0_domain" {
   value         = var.auth0_domain
 }
 
+resource "github_actions_environment_variable" "auth0_audience" {
+  repository    = data.github_repository.repo.name
+  environment   = github_repository_environment.repo_env.environment
+  variable_name = "AUTH0_AUDIENCE"
+  value         = var.auth0_audience
+}
+
 resource "github_actions_environment_variable" "auth0_client_id" {
   repository    = data.github_repository.repo.name
   environment   = github_repository_environment.repo_env.environment

--- a/secret.tf
+++ b/secret.tf
@@ -85,3 +85,25 @@ resource "github_actions_environment_secret" "github_token" {
   secret_name     = "EC2_SSH_PRIVATE_KEY"
   plaintext_value = var.ec2_private_key
 }
+
+# Additional Variables and Secret
+resource "github_actions_environment_variable" "auth0_domain" {
+  repository    = data.github_repository.repo.name
+  environment   = github_repository_environment.repo_env.environment
+  variable_name = "VITE_AUTH0_DOMAIN"
+  value         = var.auth0_domain
+}
+
+resource "github_actions_environment_variable" "auth0_client_id" {
+  repository    = data.github_repository.repo.name
+  environment   = github_repository_environment.repo_env.environment
+  variable_name = "VITE_AUTH0_CLIENT_ID"
+  value         = var.auth0_client_id
+}
+
+resource "github_actions_environment_secret" "auth0_client_secret" {
+  repository      = data.github_repository.repo.name
+  environment     = github_repository_environment.repo_env.environment
+  secret_name     = "VITE_AUTH0_CLIENT_SECRET"
+  plaintext_value = var.auth0_client_secret
+}

--- a/secret.tf
+++ b/secret.tf
@@ -16,25 +16,25 @@ resource "github_actions_environment_variable" "ec2_public_ip" {
 }
 
 # Backend Database Secrets
-# resource "github_actions_environment_variable" "db_username" {
-#   repository    = data.github_repository.repo.name
-#   environment   = github_repository_environment.repo_env.environment
-#   variable_name = "DB_USER"
-#   value         = var.db_username
-# }
+resource "github_actions_environment_variable" "db_username" {
+  repository    = data.github_repository.repo.name
+  environment   = github_repository_environment.repo_env.environment
+  variable_name = "DB_USERNAME"
+  value         = var.db_username
+}
 
-# resource "github_actions_environment_secret" "db_password" {
-#   repository      = data.github_repository.repo.name
-#   environment     = github_repository_environment.repo_env.environment
-#   secret_name     = "DB_PASSWORD"
-#   plaintext_value = var.db_password
-# }
-# resource "github_actions_environment_secret" "db_connection_url" {
-#   repository      = data.github_repository.repo.name
-#   environment     = github_repository_environment.repo_env.environment
-#   secret_name     = "DB_URL"
-#   plaintext_value = format("jdbc:postgresql://%s/%s", module.rds.db_endpoint, var.db_schema)
-# }
+resource "github_actions_environment_secret" "db_password" {
+  repository      = data.github_repository.repo.name
+  environment     = github_repository_environment.repo_env.environment
+  secret_name     = "DB_PASSWORD"
+  plaintext_value = var.db_password
+}
+resource "github_actions_environment_secret" "db_connection_url" {
+  repository      = data.github_repository.repo.name
+  environment     = github_repository_environment.repo_env.environment
+  secret_name     = "DB_URL"
+  plaintext_value = format("jdbc:postgresql://%s/%s", var.db_endpoint, var.db_schema)
+}
 
 # AWS Credentials
 resource "github_actions_environment_secret" "aws_access_key_id" {

--- a/secret.tf
+++ b/secret.tf
@@ -33,7 +33,7 @@ resource "github_actions_environment_secret" "db_connection_url" {
   repository      = data.github_repository.repo.name
   environment     = github_repository_environment.repo_env.environment
   secret_name     = "DB_URL"
-  plaintext_value = format("jdbc:postgresql://%s/%s", module.rds.db_endpoint, var.db_schema)
+  plaintext_value = format("jdbc:postgresql://%s/%s", var.db_endpoint, var.db_schema)
 }
 
 # AWS Credentials

--- a/secret.tf
+++ b/secret.tf
@@ -16,25 +16,25 @@ resource "github_actions_environment_variable" "ec2_public_ip" {
 }
 
 # Backend Database Secrets
-resource "github_actions_environment_variable" "db_username" {
-  repository    = data.github_repository.repo.name
-  environment   = github_repository_environment.repo_env.environment
-  variable_name = "DB_USER"
-  value         = var.db_username
-}
+# resource "github_actions_environment_variable" "db_username" {
+#   repository    = data.github_repository.repo.name
+#   environment   = github_repository_environment.repo_env.environment
+#   variable_name = "DB_USER"
+#   value         = var.db_username
+# }
 
-resource "github_actions_environment_secret" "db_password" {
-  repository      = data.github_repository.repo.name
-  environment     = github_repository_environment.repo_env.environment
-  secret_name     = "DB_PASSWORD"
-  plaintext_value = var.db_password
-}
-resource "github_actions_environment_secret" "db_connection_url" {
-  repository      = data.github_repository.repo.name
-  environment     = github_repository_environment.repo_env.environment
-  secret_name     = "DB_URL"
-  plaintext_value = format("jdbc:postgresql://%s/%s", var.db_endpoint, var.db_schema)
-}
+# resource "github_actions_environment_secret" "db_password" {
+#   repository      = data.github_repository.repo.name
+#   environment     = github_repository_environment.repo_env.environment
+#   secret_name     = "DB_PASSWORD"
+#   plaintext_value = var.db_password
+# }
+# resource "github_actions_environment_secret" "db_connection_url" {
+#   repository      = data.github_repository.repo.name
+#   environment     = github_repository_environment.repo_env.environment
+#   secret_name     = "DB_URL"
+#   plaintext_value = format("jdbc:postgresql://%s/%s", module.rds.db_endpoint, var.db_schema)
+# }
 
 # AWS Credentials
 resource "github_actions_environment_secret" "aws_access_key_id" {

--- a/secret.tf
+++ b/secret.tf
@@ -35,12 +35,6 @@ resource "github_actions_environment_secret" "db_connection_url" {
   secret_name     = "DB_URL"
   plaintext_value = format("jdbc:postgresql://%s/%s", module.rds.db_endpoint, var.db_schema)
 }
-resource "github_actions_environment_secret" "jwt_secret" {
-  repository      = data.github_repository.repo.name
-  environment     = github_repository_environment.repo_env.environment
-  secret_name     = "JWT_SECRET"
-  plaintext_value = var.jwt_secret
-}
 
 # AWS Credentials
 resource "github_actions_environment_secret" "aws_access_key_id" {

--- a/tfplan
+++ b/tfplan
@@ -1,1 +1,1 @@
-{"remote_plan_format":1,"run_id":"run-SRa5UrduTjVzRzyK","hostname":"app.terraform.io"}
+{"remote_plan_format":1,"run_id":"run-d9rwGheqRt3HibxB","hostname":"app.terraform.io"}

--- a/tfplan
+++ b/tfplan
@@ -1,1 +1,1 @@
-{"remote_plan_format":1,"run_id":"run-d9rwGheqRt3HibxB","hostname":"app.terraform.io"}
+{"remote_plan_format":1,"run_id":"run-9Y7bMWuAiJvJUr1w","hostname":"app.terraform.io"}

--- a/tfplan
+++ b/tfplan
@@ -1,1 +1,1 @@
-{"remote_plan_format":1,"run_id":"run-9Y7bMWuAiJvJUr1w","hostname":"app.terraform.io"}
+{"remote_plan_format":1,"run_id":"run-dAJhukXbckybDmar","hostname":"app.terraform.io"}

--- a/tfplan
+++ b/tfplan
@@ -1,1 +1,0 @@
-{"remote_plan_format":1,"run_id":"run-dAJhukXbckybDmar","hostname":"app.terraform.io"}

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,12 @@ variable "auth0_domain" {
   type        = string
   default     = "dev-ps2b4tn12sg823uw.us.auth0.com"
 }
+
+variable "auth0_audience" {
+  description = "Auth0 audience for authentication"
+  type        = string
+  default     = "https://dev-ps2b4tn12sg823uw.us.auth0.com/api/v2/"
+}
 variable "auth0_client_id" {
   description = "Auth0 client ID for authentication"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,19 @@ variable "domain_name" {
   type        = string
   default     = "MyAccountingProject.com"
 }
+
+variable "auth0_domain" {
+  description = "Auth0 domain for authentication"
+  type        = string
+  default     = "dev-ps2b4tn12sg823uw.us.auth0.com"
+}
+variable "auth0_client_id" {
+  description = "Auth0 client ID for authentication"
+  type        = string
+  default     = "b40loEEHHYu6z9OQQHItaEdwRANnfmPF"
+}
+variable "auth0_client_secret" {
+  description = "Auth0 client secret for authentication"
+  type        = string
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -98,5 +98,5 @@ variable "query_service_port" {
 variable "domain_name" {
   description = "Domain name for ACM certificate and Route53 hosted zone"
   type        = string
-  default     = "CqrsAccountingProject.com"
+  default     = "MyAccountingProject.com"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,6 @@ variable "aws_secret_key" {
 variable "db_username" {
   description = "RDS root username for the database"
   type        = string
-  default     = "db_master"
 }
 
 variable "db_password" {
@@ -36,7 +35,11 @@ variable "db_password" {
 variable "db_schema" {
   description = "RDS database name to be created."
   type        = string
-  default     = "record"
+}
+
+variable "db_endpoint" {
+  description = "RDS database endpoint"
+  type        = string
 }
 
 variable "github_owner" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,11 +39,6 @@ variable "db_schema" {
   default     = "record"
 }
 
-variable "jwt_secret" {
-  description = "Secret key for signing JWT tokens"
-  type        = string
-  sensitive   = true
-}
 variable "github_owner" {
   description = "GitHub repository owner"
   type        = string
@@ -79,6 +74,17 @@ variable "ec2_private_key" {
   sensitive   = true
 }
 
+variable "ec2_instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.nano"
+}
+
+variable "ec2_public_key" {
+  description = "SSH Public Key for EC2 instance access"
+  type        = string
+}
+
 variable "working_directory" {
   description = "Working directory for the project"
   type        = string
@@ -104,18 +110,15 @@ variable "domain_name" {
 variable "auth0_domain" {
   description = "Auth0 domain for authentication"
   type        = string
-  default     = "dev-ps2b4tn12sg823uw.us.auth0.com"
 }
 
 variable "auth0_audience" {
   description = "Auth0 audience for authentication"
   type        = string
-  default     = "https://dev-ps2b4tn12sg823uw.us.auth0.com/api/v2/"
 }
 variable "auth0_client_id" {
   description = "Auth0 client ID for authentication"
   type        = string
-  default     = "b40loEEHHYu6z9OQQHItaEdwRANnfmPF"
 }
 variable "auth0_client_secret" {
   description = "Auth0 client secret for authentication"


### PR DESCRIPTION
Improves infrastructure setup for HTTPS, load balancing, and domain management.

- Configures ACM for SSL certificate management.
- Sets up an ALB to handle HTTP and HTTPS traffic, including redirects.
- Integrates with Route53 for DNS record management, including A records for the domain and www subdomain.
- Removes the RDS module

Adds Auth0 environment variables to GitHub.

Updates Terraform versions.

## Summary by Sourcery

Configure HTTPS-enabled application load balancing, DNS, and GitHub environment settings while removing the RDS database module.

New Features:
- Introduce HTTPS-enabled ALB with HTTP-to-HTTPS redirection, multiple target groups, and path-based routing for command and query APIs.
- Set up Route53 DNS A records for the primary domain and www subdomain pointing to the ALB.
- Add GitHub Actions environment variables and secrets for Auth0-based authentication configuration.

Enhancements:
- Refine VPC, subnets, security groups, and EC2 configuration to support dual-stack (IPv4/IPv6), configurable instance type, and managed SSH key pair.
- Expose new infrastructure outputs for ALB details, SSL certificate ARN, and application URL, and update Terraform backend workspace name and required version.